### PR TITLE
Fix build by removing invalid fonts and excluding extra folder

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,9 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         {children}
       </body>
     </html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "nexvision-ui"]
 }


### PR DESCRIPTION
## Summary
- remove unavailable fonts so build does not depend on external downloads
- exclude the nested `nexvision-ui` folder from TypeScript compilation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68502a709aa0832fbeb45d5df07a4dc7